### PR TITLE
feat: fix alert conditions thresholds

### DIFF
--- a/tutornewrelic/newrelic/client.py
+++ b/tutornewrelic/newrelic/client.py
@@ -280,24 +280,8 @@ class NewRelicClient:
                     "fillOption": "STATIC",
                     "fillValue": 0,
                 },
-                "terms": [
-                    {
-                        "threshold": 1,
-                        "thresholdOccurrences": "AT_LEAST_ONCE",
-                        "thresholdDuration": 300,
-                        "operator": "BELOW",
-                        "priority": "WARNING",
-                    },
-                    {
-                        "threshold": 1,
-                        "thresholdOccurrences": "AT_LEAST_ONCE",
-                        "thresholdDuration": 600,
-                        "operator": "BELOW",
-                        "priority": "CRITICAL",
-                    },
-                ],
                 "expiration": {
-                    "expirationDuration": 120,
+                    "expirationDuration": 360,
                     "openViolationOnExpiration": True,
                 },
             },


### PR DESCRIPTION
We only need the signal loss (aka. expiration), since for the queries that are used we only get values of 1 or None (aka. no signal). The window for loss signal (i.e. how long to wait for signal to be missing before it's considered a signal loss) should be at least 6 minutes, since the synthetic monitors are pinging the URL once every 5 minutes (the window should be bigger than the frequency of the pings).