### PR TITLE
feat: adds alert state to the email subject

### DIFF
--- a/tutornewrelic/newrelic/client.py
+++ b/tutornewrelic/newrelic/client.py
@@ -442,7 +442,12 @@ class NewRelicClient:
               name: $name
               destinationId: $destinationId
               product: IINT
-              properties: []
+              properties: [
+                {
+                  key: "subject"
+                  value: "{{state}} - {{issueTitle}}"
+                }
+              ]
             }
           ) {
             channel {


### PR DESCRIPTION
The default value of the email subject is {{issueTitle}} which triggers emails with something like "<url> query result is > 0.0" when an issue is opened & closed. It makes it difficult to see what's acutally happening when multiple alerts come in at the same time.

This commit adds the alert state directly to the subject so emails would be ACTIVATE - <url> query... and CLOSED - <url query.. making it easier to quickly parse what's happening.